### PR TITLE
  Fix separator for BoundOptions query string 

### DIFF
--- a/YelpSharp/Data/Options/BoundOptions.cs
+++ b/YelpSharp/Data/Options/BoundOptions.cs
@@ -59,7 +59,7 @@ namespace YelpSharp.Data.Options
         {
             return new Dictionary<string,string> {
                 { 
-                    "bounds", string.Format("{0},{1},{2},{3}", sw_latitude, sw_longitude, ne_latitude, ne_longitude)
+                    "bounds", string.Format("{0},{1}|{2},{3}", sw_latitude, sw_longitude, ne_latitude, ne_longitude)
                 }
             };
 

--- a/YelpSharpTests/YelpTest.cs
+++ b/YelpSharpTests/YelpTest.cs
@@ -217,6 +217,29 @@ namespace YelpSharpTests
             var yelp = new Yelp(Config.Options);
             var searchOptions = new YelpSharp.Data.Options.SearchOptions()
             {
+                LocationOptions = new BoundOptions()
+                {
+                    sw_latitude = 37.9,
+                    sw_longitude = -122.5,
+                    ne_latitude = 37.788022,
+                    ne_longitude = -122.399797
+                }
+            };
+            var results = yelp.Search(searchOptions).Result;
+            Assert.IsTrue(results.businesses.Count > 0);
+        }
+        #endregion
+
+        #region LocationByBounds
+        /// <summary>
+        /// check using bounds location options
+        /// </summary>
+        [TestMethod]
+        public void LocationByBounds()
+        {
+            var yelp = new Yelp(Config.Options);
+            var searchOptions = new YelpSharp.Data.Options.SearchOptions()
+            {
                 GeneralOptions = new GeneralOptions() { radius_filter = 5 },
                 LocationOptions = new CoordinateOptions()
                 {


### PR DESCRIPTION
The query string parameter separating the coordinate pairs is incorrect for the `BoundOptions.GetParameters()` method. According to the [Yelp API](http://www.yelp.com/developers/documentation/v2/search_api#searchGBB), the query string should be:

```
bounds=sw_latitude,sw_longitude|ne_latitude,ne_longitude
```

But currently it is implemented as:

```
bounds=sw_latitude,sw_longitude,ne_latitude,ne_longitude
```

This change fixes the query string and adds a test case.
