### PR TITLE
Fixing review image URL property names to match Yelp Business API v2 spec

### DIFF
--- a/YelpSharp/Data/Review.cs
+++ b/YelpSharp/Data/Review.cs
@@ -24,17 +24,17 @@ namespace YelpSharp.Data
         /// <summary>
         /// URL to star rating image for this business (size = 84x17)
         /// </summary>
-        public string rating_img_url { get; set; }
+        public string rating_image_url { get; set; }
 
         /// <summary>
         /// URL to small version of rating image for this business (size = 50x10)
         /// </summary>
-        public string rating_img_url_small { get; set; }
+        public string rating_image_small_url { get; set; }
 
         /// <summary>
         /// url	URL to large version of rating image for this business (size = 166x30)
         /// </summary>
-        public string rating_img_url_large { get; set; }
+        public string rating_image_large_url { get; set; }
 
         /// <summary>
         /// Time created (Unix timestamp)

--- a/YelpSharpTests/GeneralTests.cs
+++ b/YelpSharpTests/GeneralTests.cs
@@ -184,7 +184,28 @@ namespace YelpSharpTests
             var results = y.GetBusiness("yelp-san-francisco").Result;
             Assert.IsTrue(results != null);
         }
-        
+
+		/// <summary>
+		/// test that reviews are returned
+		/// </summary>
+		[TestMethod]
+		public void BusinessReviewTest()
+		{
+			var y = new Yelp(Config.Options);
+			var results = y.GetBusiness("yelp-san-francisco").Result;
+			Assert.IsTrue(results != null);
+
+			Assert.IsNotNull(results.reviews);
+			Assert.AreNotEqual(0, results.review_count);
+
+			Assert.AreNotEqual(0, results.reviews.Count);
+
+			var firstReview = results.reviews[0];
+			Assert.IsNotNull(firstReview.rating_image_url);
+			Assert.IsNotNull(firstReview.rating_image_small_url);
+			Assert.IsNotNull(firstReview.rating_image_large_url);
+		}
+
         /// <summary>
         /// perform a search with multiple categories on the general options filter
         /// </summary>


### PR DESCRIPTION
This commit fixes the property names for the review image URLs which were incorrect and cause deserialization to fail.  Property names were updated to match the Yelp Business API v2 specification per http://www.yelp.com/developers/documentation/v2/business
